### PR TITLE
Add cert-manager

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,8 +53,7 @@ commands:
           name: linting helmfiles for cluster << parameters.cluster >>
           command: |
             set -e
-            helmfile --file . -e << parameters.cluster >> lint \
-              | grep -v 'error copying from remote stream to local connection'
+            helmfile -e << parameters.cluster >> lint
   # diff the k8s-bundle helmfiles with a given k8s cluster
   helmfile_diff:
     description: diff the k8s-bundle helmfiles with a given k8s cluster
@@ -67,10 +66,7 @@ commands:
           name: diffing helmfiles against cluster << parameters.cluster >>
           command: |
             set -e
-            # script --flush --quiet --return /tmp/diff-output.txt --command
-            helmfile -e << parameters.cluster >> --file . \
-              diff --suppress-secrets --concurrency=4 \
-                | grep -v 'error copying from remote stream to local connection'
+            helmfile -e << parameters.cluster >> diff --suppress-secrets
   # apply the k8s-bundle helmfiles into a given k8s cluster
   helmfile_apply:
     description: apply the k8s-bundle helmfiles into a given k8s cluster
@@ -83,8 +79,7 @@ commands:
           name: applying helmfiles against cluster << parameters.cluster >>
           command: |
             set -e
-            helmfile --file . -e << parameters.cluster >> sync --concurrency=4 \
-              | grep -v 'error copying from remote stream to local connection'
+            helmfile -e << parameters.cluster >> sync
 
 jobs:
   # lint the k8s-bundle helmfiles for a given k8s cluster

--- a/environments/k8s-mirana.yaml.gotmpl
+++ b/environments/k8s-mirana.yaml.gotmpl
@@ -9,3 +9,6 @@ cluster:
 
 ingress:
   enabled: true
+
+cert_manager:
+  enabled: true

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -6,6 +6,8 @@ environments:
 repositories:
   - name: georgedriver
     url: https://georgedriver.github.io/helm-charts
+  - name: jetstack
+    url: https://charts.jetstack.io
 
 helmDefaults:
   wait: true
@@ -17,4 +19,28 @@ releases:
     chart: georgedriver/nginx-ingress-docker-for-mac
     namespace: ingress-nginx
     version: 0.1.1
+{{- end }}
+
+{{- if .Environment.Values.cert_manager.enabled }}
+  - name: cert-manager
+    chart: jetstack/cert-manager
+    version: v0.15.1
+    namespace: cert-manager
+    set:
+      - name: installCRDs
+        value: true
+
+  - name: cert-manager-alidns-webhook
+    chart: georgedriver/alidns-webhook
+    version: 0.1.0
+    namespace: cert-manager
+    set:
+      - name: alicloud_access_key
+        value: {{ requiredEnv "ALICLOUD_ACCESS_KEY"}}
+      - name: alicloud_secret_key
+        value: {{ requiredEnv "ALICLOUD_SECRET_KEY"}}
+      - name: domain
+        value: cndriver.tech
+      - name: email
+        value: george9012@hotmail.com
 {{- end }}


### PR DESCRIPTION
## jetstack/cert-manager
cert-manager runs within your Kubernetes cluster as a series of deployment resources. It utilizes CustomResourceDefinitions to configure Certificate Authorities and request certificates.

Homepage: https://cert-manager.io/docs/installation/kubernetes/
If you install this cert-manager into your Kubernetes, you must also need to installed below [georgedriver/alidns-webhook](https://github.com/georgedriver/helm-charts/tree/master/charts/alidns-webhook) chart as well.

## georgedriver/alidns-webhook
Homepage: https://github.com/georgedriver/helm-charts/tree/master/charts/alidns-webhook

I build this helm chart based on [pragkent/alidns-webhook](https://github.com/pragkent/alidns-webhook),  it has a lot of defects, please DO NOT use this in your production environment.

You must install jetstack/cert-manager before installing this helm chart, otherwise some unknown CRD errors will show up.

## Update circleci pipeline